### PR TITLE
Release automation through CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,4 +56,5 @@ workflows:
             - build
           filters:
             branches:
-              only: release
+              only: master
+              

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,34 +29,21 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: go get -u github.com/mitchellh/gox
-      - run: go get -u github.com/tcnksm/ghr
-      - run: go get -u github.com/stevenmatthewt/semantics
       - run:
           name: Docker build and push
           command: |
-            COMMIT_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
+            COMMIT_TAG=$(echo $CIRCLE_SHA1 | cut -c -7) 
             echo 'export COMMIT_TAG="$(echo $CIRCLE_SHA1 | cut -c -7)"' >> $BASH_ENV
-            docker login -u $DOCKER_USER -p $DOCKER_PASS $REGISTRY_HOST
-            env IMAGE=$REGISTRY_HOST/smi-metrics TAG=$COMMIT_TAG make push
+            docker login docker.pkg.github.com -u $GITHUB_USER -p $GITHUB_TOKEN
+            env IMAGE=docker.pkg.github.com/$GITHUB_USER/smi-metrics/smi-metrics TAG=$COMMIT_TAG make push
       - add_ssh_keys:
           fingerprints:
-            - "<<InsertFingerprintHere>>"
+            - "<<InsertFingerPrinthere>>"
       - run:
-          name: Checking for a release structure on commit, and performing a github release if needed
+          name: Checking if the commit is a release
           command: |
-            set +e
-            tag=$(semantics --output-tag)
-            if [ $? -eq 0 ]; then
-              docker tag $REGISTRY_HOST/smi-metrics:COMMIT_TAG $REGISTRY_HOST/smi-metrics:$tag
-              docker push $REGISTRY_HOST/smi-metrics:$tag
-              env GO111MODULE=on make vendor
-              make binaries
-              cd dist/ && gzip *
-              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag ./
-            else
-              echo "The commit message(s) did not indicate a major/minor/patch version."
-            fi
+           env IMAGE=docker.pkg.github.com/$GITHUB_USER/smi-metrics/smi-metrics make release
+
 
 workflows:
   version: 2
@@ -69,4 +56,4 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,28 +33,27 @@ jobs:
       - run: go get -u github.com/tcnksm/ghr
       - run: go get -u github.com/stevenmatthewt/semantics
       - run:
-          name: cross compiling
+          name: Docker build and push
           command: |
-            env GO111MODULE=on go mod vendor
-            gox -os="linux darwin windows" -arch="amd64" -output="dist/smi_metrics_{{.OS}}_{{.Arch}}" ./cmd/smi-metrics
-            cd dist/ && gzip *
-      - run:
-          name: docker build
-          command: |
-            docker build -t  deislabs/smi-metrics .
+            COMMIT_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
+            echo 'export COMMIT_TAG="$(echo $CIRCLE_SHA1 | cut -c -7)"' >> $BASH_ENV
+            docker login -u $DOCKER_USER -p $DOCKER_PASS $REGISTRY_HOST
+            env IMAGE=$REGISTRY_HOST/smi-metrics TAG=$COMMIT_TAG make push
       - add_ssh_keys:
           fingerprints:
             - "<<InsertFingerprintHere>>"
       - run:
-          name: pushing docker image and creating github release
+          name: Checking for a release structure on commit, and performing a github release if needed
           command: |
             set +e
             tag=$(semantics --output-tag)
             if [ $? -eq 0 ]; then
-              docker tag deislabs/smi-metrics deislabs/smi-metrics:$tag
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker push deislabs/smi-metrics:$tag
-              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
+              docker tag $REGISTRY_HOST/smi-metrics:COMMIT_TAG $REGISTRY_HOST/smi-metrics:$tag
+              docker push $REGISTRY_HOST/smi-metrics:$tag
+              env GO111MODULE=on make vendor
+              make binaries
+              cd dist/ && gzip *
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag ./
             else
               echo "The commit message(s) did not indicate a major/minor/patch version."
             fi
@@ -71,4 +70,3 @@ workflows:
           filters:
             branches:
               only: master
-              

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
-version: 2 
+version: 2
 jobs:
-  build: 
-    docker: 
+  build:
+    docker:
       - image: circleci/golang:1.12
 
-    steps: 
+    steps:
       - checkout
       - restore_cache:
           keys:
@@ -21,8 +21,54 @@ jobs:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+  release:
+    docker:
+      - image: circleci/golang:1.12
+    working_directory: /go/src/github.com/deislabs/smi-metrics
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: go get -u github.com/mitchellh/gox
+      - run: go get -u github.com/tcnksm/ghr
+      - run: go get -u github.com/stevenmatthewt/semantics
+      - run:
+          name: cross compiling
+          command: |
+            env GO111MODULE=on go mod vendor
+            gox -os="linux darwin windows" -arch="amd64" -output="dist/smi_metrics_{{.OS}}_{{.Arch}}" ./cmd/smi-metrics
+            cd dist/ && gzip *
+      - run:
+          name: docker build
+          command: |
+            docker build -t  deislabs/smi-metrics .
+      - add_ssh_keys:
+          fingerprints:
+            - "<<InsertFingerprintHere>>"
+      - run:
+          name: pushing docker image and creating github release
+          command: |
+            set +e
+            tag=$(semantics --output-tag)
+            if [ $? -eq 0 ]; then
+              docker tag deislabs/smi-metrics deislabs/smi-metrics:$tag
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push deislabs/smi-metrics:$tag
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
+            else
+              echo "The commit message(s) did not indicate a major/minor/patch version."
+            fi
+
 workflows:
   version: 2
   build-workflow:
     jobs:
       - build
+      - release:
+          context: release-context
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+              

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,13 @@ ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 HAS_TILT := $(shell command -v tilt;)
 
+ifeq ($(TAG),)
 TAG := $(shell git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+endif
 
+ifeq ($(IMAGE),)
 IMAGE := thomasr/smi-metrics
+endif
 
 .PHONY: bootstrap
 bootstrap:
@@ -14,16 +18,24 @@ ifndef HAS_TILT
 endif
 
 .PHONY: lint
-lint: 
+lint:
 	./bin/lint --verbose
 
 .PHONY: test
-test: 
+test:
 	go test -cover -v -race ./...
+
+.PHONY: vendor
+vendor:
+	go mod vendor
 
 .PHONY: dep
 dep:
 	go mod download
+
+.PHONY: binaries
+binaries:
+	gox -os="linux darwin windows" -arch="amd64" -output="dist/smi_metrics_{{.OS}}_{{.Arch}}" ./cmd/smi-metrics
 
 .PHONY: dev
 dev: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,32 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 HAS_TILT := $(shell command -v tilt;)
+HAS_GOX := $(shell command -v gox;)
+HAS_GHR := $(shell command -v ghr;)
+HAS_SEMANTICS := $(shell command -v semantics;)
 
-ifeq ($(TAG),)
-TAG := $(shell git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+# Check for already defined environment variables
+TAG ?= $(shell git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+IMAGE ?= thomasr/smi-metrics
+
+.PHONY: release-bootstrap
+release-bootstrap:
+	@#Check for gox
+ifndef HAS_GOX
+	@echo "Installing gox"
+	go get -u github.com/mitchellh/gox
+endif
+	@#Check for ghr
+ifndef HAS_GHR
+	@echo "Installing ghr"
+	go get -u github.com/tcnksm/ghr
+endif
+	@#Check for semantics
+ifndef HAS_SEMANTICS
+	@echo "Installing semantics"
+	go get -u github.com/stevenmatthewt/semantics
 endif
 
-ifeq ($(IMAGE),)
-IMAGE := thomasr/smi-metrics
-endif
 
 .PHONY: bootstrap
 bootstrap:
@@ -40,6 +58,25 @@ binaries:
 .PHONY: dev
 dev: bootstrap
 	tilt up
+
+.PHONY: release
+release: release-bootstrap
+	set +e \
+    $(eval RELEASE_TAG=$(shell semantics --output-tag))
+	@if [ $(RELEASE_TAG) ]; then \
+	  echo "Tagging the latest commit image with tag: ${RELEASE_TAG}"; \
+	  docker tag ${IMAGE}:${COMMIT_TAG} ${IMAGE}:${RELEASE_TAG}; \
+	  echo "Pusing the docker image: ${IMAGE}:${RELEASE_TAG} "; \
+	  docker push ${IMAGE}:${RELEASE_TAG}; \
+	  echo "Generating binaries for Github Release"; \
+	  env GO111MODULE=on make vendor; \
+	  make binaries; \
+	  cd dist/ && gzip *; \
+	  echo "Pushing the Github Release"; \
+	  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace ${RELEASE_TAG} ./; \
+	else \
+	  echo "The commit message(s) did not indicate a major/minor/patch version."; \
+	fi 
 
 .PHONY: push
 push: build


### PR DESCRIPTION
Fixes #29 

This PR 
- Adds Release config that runs on every merge 
- This checks if there is a new commit with [semantics structure](https://github.com/stevenmatthewt/semantics#how-it-works), semantics will then return a release version (based on the previous version and the commit), which is then used to perform github releases and docker pushes.
- If there is no commit with a release structure, the release just exits.

For this PR to work, the following are needed.
- A [Context](https://circleci.com/docs/2.0/contexts/) in CircleCI which has `GITHUB_TOKEN`, `DOCKER_USER` and `DOCKER_PASS`
- SSH Keys in the CircleCI, with the given fingerprint added to the config file. This is needed for semantics to work.
- Semantics needs the repo to have a tag with initial version (which can be `v0.0.0`), It will work only after that as it bumps the version based on the commit message. So, a tag with some initial version should be pushed before this is merged

The Question here is
Should we push docker images for every commit with commit-id as the image tag and push after every merge as a part of the pipeline. If there is a commit with the release strucutre, That same image can be tagged with the release version and pushed to docker hub.

@grampelberg @michelleN 

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>