### PR TITLE
Single version Variable for both charts and  docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,9 @@ ifndef CIRCLE_TAG
 	@exit 1
 endif
 	cp -R chart tmp/smi-metrics
-	sed -i.bak 's/CHAT_VERSION/${VERSION}/g' tmp/smi-metrics/Chart.yaml
+	sed -i.bak 's/CHART_VERSION/${VERSION}/g' tmp/smi-metrics/Chart.yaml
 	for fname in $$(grep -rnl '$*' tmp/smi-metrics); do \
 		sed -i.bak 's/VERSION/${CIRCLE_TAG}/g' $$fname; \
-		rm $$fname.bak; \
 	done
 	helm package tmp/smi-metrics -d tmp --save=false
 	rm -rf tmp/smi-metrics/

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,11 @@ ifndef CIRCLE_TAG
 	@exit 1
 endif
 	cp -R chart tmp/smi-metrics
-	sed -i.bak 's/CHART_VERSION/${VERSION}/g' tmp/smi-metrics/Chart.yaml
+	sed -i.bak 's/CHAT_VERSION/${VERSION}/g' tmp/smi-metrics/Chart.yaml
+	for fname in $$(grep -rnl '$*' tmp/smi-metrics); do \
+		sed -i.bak 's/VERSION/${CIRCLE_TAG}/g' $$fname; \
+		rm $$fname.bak; \
+	done
 	helm package tmp/smi-metrics -d tmp --save=false
 	rm -rf tmp/smi-metrics/
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.1"
+appVersion: CHAT_VERSION
 description: Provider for metrics.smi-spec.io
 name: smi-metrics
-version: CHART_VERSION
+version: CHAT_VERSION

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: CHAT_VERSION
+appVersion: CHART_VERSION
 description: Provider for metrics.smi-spec.io
 name: smi-metrics
-version: CHAT_VERSION
+version: CHART_VERSION

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  name: thomasr/smi-metrics:v1alpha1-0.1
+  name: deislabs/smi-metrics:VERSION
   pullPolicy: IfNotPresent
 
 config:


### PR DESCRIPTION
This Pr makes the whole repo use a single version and that will be `CIRCLE_TAG`. previously `VERSION` was being used for charts. this can create two separate unecessary things.

Once, this PR merges. we should be able to do a `0.2.0`. Once that is done, I will update the docs to use the github release and perform the installation.

@grampelberg @michelleN 

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>