### PR TITLE
Move Queries struct to a common package.

### DIFF
--- a/pkg/istio/istio.go
+++ b/pkg/istio/istio.go
@@ -16,15 +16,10 @@ import (
 )
 
 type Config struct {
-	PrometheusURL    string  `yaml:"prometheusUrl"`
-	NamespaceQueries Queries `yaml:"namespaceQueries"`
-	PodQueries       Queries `yaml:"podQueries"`
-	WorkloadQueries  Queries `yaml:"workloadQueries"`
-}
-
-type Queries struct {
-	ResourceQueries map[string]string `yaml:"resourceQueries"`
-	EdgeQueries     map[string]string `yaml:"edgeQueries"`
+	PrometheusURL    string             `yaml:"prometheusUrl"`
+	NamespaceQueries prometheus.Queries `yaml:"namespaceQueries"`
+	PodQueries       prometheus.Queries `yaml:"podQueries"`
+	WorkloadQueries  prometheus.Queries `yaml:"workloadQueries"`
 }
 
 type Istio struct {

--- a/pkg/linkerd/linkerd.go
+++ b/pkg/linkerd/linkerd.go
@@ -21,13 +21,8 @@ type Config struct {
 	EdgeQueries     map[string]string `yaml:"edgeQueries"`
 }
 
-type Queries struct {
-	ResourceQueries map[string]string `yaml:"resourceQueries"`
-	EdgeQueries     map[string]string `yaml:"edgeQueries"`
-}
-
 type Linkerd struct {
-	queries          Queries
+	queries          prometheus.Queries
 	prometheusClient promv1.API
 }
 
@@ -101,7 +96,7 @@ func NewLinkerdProvider(config Config) (*Linkerd, error) {
 		return nil, err
 	}
 
-	queries := Queries{
+	queries := prometheus.Queries{
 		ResourceQueries: config.ResourceQueries,
 		EdgeQueries:     config.EdgeQueries,
 	}

--- a/pkg/linkerd/test_helpers.go
+++ b/pkg/linkerd/test_helpers.go
@@ -8,10 +8,12 @@ import (
 	"path"
 	"time"
 
+	"github.com/deislabs/smi-metrics/pkg/metrics"
+	"github.com/deislabs/smi-metrics/pkg/prometheus"
+
 	"gopkg.in/yaml.v2"
 
 	"github.com/deislabs/smi-metrics/pkg/linkerd/mocks"
-	"github.com/deislabs/smi-metrics/pkg/metrics"
 	smimetrics "github.com/deislabs/smi-sdk-go/pkg/apis/metrics"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
@@ -206,7 +208,7 @@ func (s *Suite) SetupTest() {
 	file, err := ioutil.ReadFile("test_queries.yaml")
 	s.Require().NoError(err)
 
-	var queries Queries
+	var queries prometheus.Queries
 	err = yaml.Unmarshal(file, &queries)
 	s.Require().NoError(err)
 

--- a/pkg/prometheus/helpers.go
+++ b/pkg/prometheus/helpers.go
@@ -10,6 +10,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+type Queries struct {
+	ResourceQueries map[string]string `yaml:"resourceQueries"`
+	EdgeQueries     map[string]string `yaml:"edgeQueries"`
+}
+
 func GetResourceTrafficMetricsList(ctx context.Context,
 	obj *v1.ObjectReference,
 	interval *metrics.Interval,


### PR DESCRIPTION
With this, most of the redundant code is moved out.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>