### PR TITLE
Use release namespace in chart templates

### DIFF
--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -30,6 +30,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ include "smi-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ b64enc $cert.Cert }}

--- a/chart/templates/config.yaml
+++ b/chart/templates/config.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ include "smi-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
   config.yml: |
     {{- $files := .Files }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "smi-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "smi-metrics.name" . }}
     helm.sh/chart: {{ include "smi-metrics.chart" . }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ include "smi-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "smi-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "smi-metrics.name" . }}
     helm.sh/chart: {{ include "smi-metrics.chart" . }}


### PR DESCRIPTION
When installing the Helm chart with the `--namespace` option, some fields in resources like the [`APIResource`](https://github.com/deislabs/smi-metrics/blob/4109ac7c83538ad13cb5681bbefd1aa91209a244/chart/templates/apiservice.yaml#L16) and [`ServiceAccount`](https://github.com/deislabs/smi-metrics/blob/4109ac7c83538ad13cb5681bbefd1aa91209a244/chart/templates/rbac.yaml#L29) would honor the value, while others don't, causing a problematic installation. This PR adds the `namespace` field to all namespace-scoped resources.

The diff of the YAML can be found in this [gist](https://gist.github.com/ihcsim/18764866e181362cdbcc40015186bc0b).

Tested with:
```
helm template chart --name=dev --namespace=linkerd --set adapter=linkerd | kubectl apply -f -
```

Signed-off-by: ihcsim <ihcsim@gmail.com>