### PR TITLE
Fix Tilt workflow

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,5 @@
-k8s_yaml(local("helm template chart -f dev.yaml -f linkerd.yaml --name dev"))
+k8s_yaml(local("helm template chart --set adapter=linkerd --name dev"))
 watch_file('chart')
-
-docker_build('thomasr/smi-metrics', '.')
+docker_build('deislabs/smi-metrics', '.')
 
 k8s_resource('dev-smi-metrics', port_forwards=['8080:8080', '8081:8081'])


### PR DESCRIPTION
Fixes #47 

This fixes the tiltfile to use the adapter style helm workflow. 

Users can always change the adapter flag to work with other meshes.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>