### PR TITLE
Allow any client name when allowed client names is empty

### DIFF
--- a/pkg/server/authz.go
+++ b/pkg/server/authz.go
@@ -18,6 +18,10 @@ func (s *Server) authorizer(next http.Handler) http.Handler {
 			return
 		}
 
+		if len(s.clientNames) == 0 {
+				next.ServeHTTP(w, r)
+				return
+		}
 		for _, crt := range r.TLS.PeerCertificates {
 			name := crt.Subject.CommonName
 			if _, ok := s.clientNames[name]; ok {

--- a/pkg/server/authz.go
+++ b/pkg/server/authz.go
@@ -19,8 +19,8 @@ func (s *Server) authorizer(next http.Handler) http.Handler {
 		}
 
 		if len(s.clientNames) == 0 {
-				next.ServeHTTP(w, r)
-				return
+			next.ServeHTTP(w, r)
+			return
 		}
 		for _, crt := range r.TLS.PeerCertificates {
 			name := crt.Subject.CommonName


### PR DESCRIPTION
from: https://kubernetes.io/docs/tasks/access-kubernetes-api/#authentication-flow
> The connection must be made using a client certificate whose CN is one of those listed in --requestheader-allowed-names. Note: You can set this option to blank as --requestheader-allowed-names="". This will indicate to an extension apiserver that any CN is acceptable.

Signed-off-by: Alex Leong <alex@buoyant.io>