### PR TITLE
Only use inbound metrics for resource queries

### DIFF
--- a/chart/linkerd.yaml
+++ b/chart/linkerd.yaml
@@ -9,7 +9,8 @@ linkerd:
                           irate(
                             response_latency_ms_bucket{
                               namespace=~"{{default ".+" .namespace }}",
-                              {{lower .kind}}=~"{{default ".+" .name }}"
+                              {{lower .kind}}=~"{{default ".+" .name }}",
+                              direction="inbound"
                             }[{{.window}}]
                           )
                         ) by (
@@ -25,7 +26,8 @@ linkerd:
                           irate(
                             response_latency_ms_bucket{
                               namespace=~"{{default ".+" .namespace }}",
-                              {{lower .kind}}=~"{{default ".+" .name }}"
+                              {{lower .kind}}=~"{{default ".+" .name }}",
+                              direction="inbound"
                             }[{{.window}}]
                           )
                         ) by (
@@ -41,7 +43,8 @@ linkerd:
                           irate(
                             response_latency_ms_bucket{
                               namespace=~"{{default ".+" .namespace }}",
-                              {{lower .kind}}=~"{{default ".+" .name }}"
+                              {{lower .kind}}=~"{{default ".+" .name }}",
+                              direction="inbound"
                             }[{{.window}}]
                           )
                         ) by (
@@ -56,7 +59,8 @@ linkerd:
                   response_total{
                     classification="success",
                     namespace=~"{{default ".+" .namespace }}",
-                    {{lower .kind}}=~"{{default ".+" .name }}"
+                    {{lower .kind}}=~"{{default ".+" .name }}",
+                    direction="inbound"
                   }[{{.window}}]
                 )
               ) by (
@@ -69,7 +73,8 @@ linkerd:
                   response_total{
                     classification="failure",
                     namespace=~"{{default ".+" .namespace }}",
-                    {{lower .kind}}=~"{{default ".+" .name }}"
+                    {{lower .kind}}=~"{{default ".+" .name }}",
+                    direction="inbound"
                   }[{{.window}}]
                 )
               ) by (


### PR DESCRIPTION
Linkerd resource queries were not specifying a direction in the prometheus query.  This means that the queries were returning both incoming and outgoing metrics and summing them together.  This manifested as resources appearing to have larger `RPS` values than they had in reality.

We add a direction constraint to these queries to fix the problem.

Signed-off-by: Alex Leong <alex@buoyant.io>