### PR TITLE
Add support for time window query parameter

### DIFF
--- a/pkg/metrics/helpers.go
+++ b/pkg/metrics/helpers.go
@@ -53,9 +53,16 @@ func (h *Handler) addInterval(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
+
+		t := r.URL.Query().Get("t")
+		window, err := time.ParseDuration(t)
+		if err != nil {
+			window = 30 * time.Second
+		}
+
 		ctx := context.WithValue(r.Context(), intervalKey, &metrics.Interval{
 			Timestamp: metav1.NewTime(start),
-			Window:    metav1.Duration{Duration: 30 * time.Second},
+			Window:    metav1.Duration{Duration: window},
 		})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/pkg/metrics/helpers.go
+++ b/pkg/metrics/helpers.go
@@ -53,7 +53,6 @@ func (h *Handler) addInterval(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
-
 		t := r.URL.Query().Get("t")
 		window, err := time.ParseDuration(t)
 		if err != nil {

--- a/pkg/prometheus/client.go
+++ b/pkg/prometheus/client.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"text/template"
 
 	"github.com/deislabs/smi-sdk-go/pkg/apis/metrics"
@@ -45,7 +46,8 @@ func (c *Client) render(
 	query string, opts map[string]interface{}) (string, error) {
 	buf := &bytes.Buffer{}
 
-	opts["window"] = c.interval.Window.Duration.String()
+	seconds := int(c.interval.Window.Duration.Seconds())
+	opts["window"] = fmt.Sprintf("%ds", seconds)
 
 	tmpl, err := template.New("query").Funcs(sprig.TxtFuncMap()).Parse(query)
 	if err != nil {


### PR DESCRIPTION
We add support for the `t` parameter which controls the time window over which the metrics query is calculated.  The `t` parameter may be any valid golang duration such as `30s` or `1m15s` and is rounded down to the nearest second before being passed to Prometheus.

Signed-off-by: Alex Leong <alex@buoyant.io>