### PR TITLE
Allow edges queries to see cross-namespace edges

### DIFF
--- a/chart/linkerd.yaml
+++ b/chart/linkerd.yaml
@@ -83,7 +83,8 @@ linkerd:
                         sum(
                           irate(
                             response_latency_ms_bucket{
-                              namespace=~"{{.namespace}}",
+                              namespace=~"{{default ".+" .namespace}}",
+                              dst_namespace=~"{{default ".+" .toNamespace}}",
                               {{lower .kind}}=~"{{default ".+" .fromName}}",
                               dst_{{lower .kind}}=~"{{default ".+" .toName}}"
                             }[{{.window}}]
@@ -102,7 +103,8 @@ linkerd:
                         sum(
                           irate(
                             response_latency_ms_bucket{
-                              namespace=~"{{.namespace}}",
+                              namespace=~"{{default ".+" .namespace}}",
+                              dst_namespace=~"{{default ".+" .toNamespace}}",
                               {{lower .kind}}=~"{{default ".+" .fromName}}",
                               dst_{{lower .kind}}=~"{{default ".+" .toName}}"
                             }[{{.window}}]
@@ -121,7 +123,8 @@ linkerd:
                         sum(
                           irate(
                             response_latency_ms_bucket{
-                              namespace=~"{{.namespace}}",
+                              namespace=~"{{default ".+" .namespace}}",
+                              dst_namespace=~"{{default ".+" .toNamespace}}",
                               {{lower .kind}}=~"{{default ".+" .fromName}}",
                               dst_{{lower .kind}}=~"{{default ".+" .toName}}"
                             }[{{.window}}]
@@ -139,7 +142,8 @@ linkerd:
                 increase(
                   response_total{
                     classification="success",
-                    namespace=~"{{.namespace}}",
+                    namespace=~"{{default ".+" .namespace}}",
+                    dst_namespace=~"{{default ".+" .toNamespace}}",
                     {{lower .kind}}=~"{{default ".+" .fromName}}",
                     dst_{{lower .kind}}=~"{{default ".+" .toName}}"
                   }[{{.window}}]
@@ -155,7 +159,8 @@ linkerd:
                 increase(
                   response_total{
                     classification="failure",
-                    namespace=~"{{.namespace}}",
+                    namespace=~"{{default ".+" .namespace}}",
+                    dst_namespace=~"{{default ".+" .toNamespace}}",
                     {{lower .kind}}=~"{{default ".+" .fromName}}",
                     dst_{{lower .kind}}=~"{{default ".+" .toName}}"
                   }[{{.window}}]

--- a/pkg/prometheus/edge.go
+++ b/pkg/prometheus/edge.go
@@ -54,9 +54,9 @@ func (e *EdgeLookup) Queries() []*Query {
 			Name:     name,
 			Template: tmpl,
 			Values: map[string]interface{}{
-				"kind":      e.Item.Resource.Kind,
+				"kind":        e.Item.Resource.Kind,
 				"toNamespace": e.Item.Resource.Namespace,
-				"toName":    e.Item.Resource.Name,
+				"toName":      e.Item.Resource.Name,
 			},
 		})
 	}

--- a/pkg/prometheus/edge.go
+++ b/pkg/prometheus/edge.go
@@ -55,7 +55,7 @@ func (e *EdgeLookup) Queries() []*Query {
 			Template: tmpl,
 			Values: map[string]interface{}{
 				"kind":      e.Item.Resource.Kind,
-				"namespace": e.Item.Resource.Namespace,
+				"toNamespace": e.Item.Resource.Namespace,
 				"toName":    e.Item.Resource.Name,
 			},
 		})


### PR DESCRIPTION
Linkerd edge queries in Prometheus have the label constraint that "namespace" must match the resource namespace.  The "namespace" Prometheus label refers to the label of the source resource.  In the case of a "from" edge, the source resource might be in a different namespace and therefore get excluded by this query.

We distinguish between the "namespace" (source) and "toNamespace" (destination) to properly include all "from" edges, even from resources in other namespaces.

Signed-off-by: Alex Leong <alex@buoyant.io>