### PR TITLE
Fix Release Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,11 @@ on:
   pull_request: {}
   push:
     tags:
-      - 'v*.*.*'
+    - 'v*.*.*'
     paths-ignore:
     - '*.md'
     - '**/*.md'
-    branches:
-    - master
+
 jobs:
   go_build_test:
     name: Go Build and Test
@@ -37,18 +36,22 @@ jobs:
       run: |
         make build
   release:
-    name: Docker Push and Release
+    name: Docker Push and Github Release
     needs: docker_build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'v')
     steps:
-    - name: Set env
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+    - name: Checkout code
+      uses: actions/checkout@master
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13.8
     - name: Docker Build and Push
+      if: github.event_name == 'push'
       run: |
+        export RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}
+        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        export PATH=${PATH}:`go env GOPATH`/bin
         docker login -u ${{ secrets.DOCKER_USER}} -p ${{ secrets.DOCKER_PASS}}  && \
         make push
-    - name: Performing a Github release
-      run: |
-        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         make release

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 HAS_TILT := $(shell command -v tilt;)
 HAS_GHR := $(shell command -v ghr;)
-HAS_HELM := $(shell command -v helm;)
 
 
 IMAGE_NAME      ?= deislabs/smi-metrics
@@ -17,13 +16,12 @@ endif
 
 .PHONY: release-bootstrap
 release-bootstrap:
+	@echo "Installing Helm v2"
+	set -x; curl -L https://git.io/get_helm.sh | bash
 	@#Check for ghr
 ifndef HAS_GHR
 	@echo "Installing ghr"
 	go get -u github.com/tcnksm/ghr
-endif
-ifndef HAS_HELM
-	set -x; curl -L https://git.io/get_helm.sh | bash
 endif
 
 .PHONY: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 HAS_TILT := $(shell command -v tilt;)
-HAS_GOX := $(shell command -v gox;)
 HAS_GHR := $(shell command -v ghr;)
 HAS_HELM := $(shell command -v helm;)
 
@@ -18,11 +17,6 @@ endif
 
 .PHONY: release-bootstrap
 release-bootstrap:
-	@#Check for gox
-ifndef HAS_GOX
-	@echo "Installing gox"
-	go get -u github.com/mitchellh/gox
-endif
 	@#Check for ghr
 ifndef HAS_GHR
 	@echo "Installing ghr"


### PR DESCRIPTION
This PR
- Removes dependency on `gox` for releases, as we are not using it.
- Makes sure helm v2 is installed, as some in-compatible version is already installed on the actions agent.
- Makes sure relevant env variables are set to perform a release

Also, This PR makes the workflow not run on all pushes to the master, but only to the pushes that have `v*.*.*` as the tag.

**To Perform a Release**
- Just add a relevant tag and push